### PR TITLE
Updated metrics to show an empty state if there are no PRs with a cycle time

### DIFF
--- a/src/MetricTiles.tsx
+++ b/src/MetricTiles.tsx
@@ -80,16 +80,21 @@ function MetricTiles({ pullRequests }: Props) {
           {renderTileValue('Merged Pull Requests', mergedPullRequests)}
         </Grid>
         <Grid item xs={2} sm={4} md={4}>
-          {renderTileValue('Median Cycle Time', getMedian(cycleTimes))}
+          {renderTileValue('Median Cycle Time', getMedian(cycleTimes) || '-')}
         </Grid>
         <Grid item xs={2} sm={4} md={4}>
           {renderTileValue(
             'Average Cycle Time',
-            Math.round(getAverage(cycleTimes) * 100) / 100
+            cycleTimes.length > 0
+              ? Math.round(getAverage(cycleTimes) * 100) / 100
+              : '-'
           )}
         </Grid>
         <Grid item xs={2} sm={4} md={4}>
-          {renderTileValue('Worst Cycle Time', getHighest(cycleTimes))}
+          {renderTileValue(
+            'Worst Cycle Time',
+            cycleTimes.length > 0 ? getHighest(cycleTimes) : '-'
+          )}
         </Grid>
       </TileContainer>
     </Box>


### PR DESCRIPTION
![Screen Shot 2022-05-02 at 6 00 32 PM](https://user-images.githubusercontent.com/7210022/166334393-dd753cf1-cde4-4777-a4d1-651e88f98dff.png)
