### PR TITLE
Improve handling of force pushes

### DIFF
--- a/src/MetricTiles.tsx
+++ b/src/MetricTiles.tsx
@@ -52,7 +52,7 @@ const renderTileValue = (title: string, value: any, helpText: string) => {
 
 function MetricTiles({ pullRequests, reviewedPullRequests }: Props) {
   const authoredCycleTimes: number[] = pullRequests
-    .filter((pull) => pull.state === 'MERGED')
+    .filter((pull) => pull.state === 'MERGED' && typeof pull.cycleTime === 'number' )
     .map((pull) => pull.cycleTime as number);
 
   const reviewResponseTimes: number[] = reviewedPullRequests

--- a/src/MetricTiles.tsx
+++ b/src/MetricTiles.tsx
@@ -52,21 +52,29 @@ const renderTileValue = (title: string, value: any, helpText: string) => {
 
 function MetricTiles({ pullRequests, reviewedPullRequests }: Props) {
   const authoredCycleTimes: number[] = pullRequests
-    .filter((pull) => pull.state === 'MERGED' && typeof pull.cycleTime === 'number' )
+    .filter(
+      (pull) => pull.state === 'MERGED' && typeof pull.cycleTime === 'number'
+    )
     .map((pull) => pull.cycleTime as number);
 
   const reviewResponseTimes: number[] = reviewedPullRequests
-    .filter((pull) => pull.state === 'MERGED' && typeof pull.reworkTimeInDays === 'number')
+    .filter(
+      (pull) =>
+        pull.state === 'MERGED' && typeof pull.reworkTimeInDays === 'number'
+    )
     .map((pull) => pull.daysToFirstReview as number);
 
   const reviewDurations: number[] = reviewedPullRequests
-    .filter((pull) => pull.state === 'MERGED' && typeof pull.reworkTimeInDays === 'number')
+    .filter(
+      (pull) =>
+        pull.state === 'MERGED' && typeof pull.reworkTimeInDays === 'number'
+    )
     .map((pull) => pull.reworkTimeInDays as number);
 
   const openPullRequests = pullRequests.filter(
     (pull) => pull.state === 'OPEN'
   ).length;
-  
+
   const mergedPullRequests = pullRequests.filter(
     (pull) => pull.state === 'MERGED'
   ).length;
@@ -79,22 +87,30 @@ function MetricTiles({ pullRequests, reviewedPullRequests }: Props) {
     <Box sx={{ flexGrow: 1, height: '100%' }}>
       <TileContainer container columnSpacing={2} rowSpacing={1}>
         <Grid item xs={2} sm={3} md={3}>
-          {renderTileValue('Authored Pull Requests', pullRequests.length, 
+          {renderTileValue(
+            'Authored Pull Requests',
+            pullRequests.length,
             'Total pull requests that this user has authored'
           )}
         </Grid>
         <Grid item xs={2} sm={3} md={3}>
-          {renderTileValue('Open Pull Requests', openPullRequests,
+          {renderTileValue(
+            'Open Pull Requests',
+            openPullRequests,
             'Total pull requests that this user currently has open'
           )}
         </Grid>
         <Grid item xs={2} sm={3} md={3}>
-          {renderTileValue('Merged Pull Requests', mergedPullRequests, 
+          {renderTileValue(
+            'Merged Pull Requests',
+            mergedPullRequests,
             'Total pull requests that this user opened and later merged'
           )}
         </Grid>
         <Grid item xs={2} sm={3} md={3}>
-          {renderTileValue('Closed Pull Requests', closedPullRequests,
+          {renderTileValue(
+            'Closed Pull Requests',
+            closedPullRequests,
             'Total pull requests that this user opened and later closed'
           )}
         </Grid>

--- a/src/PullRequestMetricsTable.tsx
+++ b/src/PullRequestMetricsTable.tsx
@@ -48,7 +48,7 @@ const makeColumns = (gitHubBaseUri: string): GridColDef[] => [
   { field: 'totalCodeChanges', headerName: 'Total Code Changes' },
   {
     field: 'commitToPullRequest',
-    headerName: 'Development',
+    headerName: 'Commit to PR',
     type: 'number',
     width: 150,
   },
@@ -76,6 +76,12 @@ const makeColumns = (gitHubBaseUri: string): GridColDef[] => [
     headerName: 'Deployment Time',
     type: 'dateTime',
     width: 175,
+  },
+  {
+    field: 'forcePush',
+    headerName: 'Force pushed',
+    type: 'boolean',
+    width: 125,
   },
   { field: 'author', headerName: 'Author' },
 ];

--- a/src/cycle-time/getEarliestCommitAt.ts
+++ b/src/cycle-time/getEarliestCommitAt.ts
@@ -36,7 +36,7 @@ export const getEarliestCommitAt = (pullRequest: PullRequest) => {
       }
 
       // Force pushes
-      if ('beforeCommit' in node && 'afterCommit' in node) {
+      if ('beforeCommit' in node && 'afterCommit' in node && node.beforeCommit && node.afterCommit) {
         const afterCommitMap = keyBy(
           node.afterCommit.history.edges,
           (connection: CommitEdge) => connection.node.oid

--- a/src/cycle-time/getEarliestCommitAt.ts
+++ b/src/cycle-time/getEarliestCommitAt.ts
@@ -36,7 +36,12 @@ export const getEarliestCommitAt = (pullRequest: PullRequest) => {
       }
 
       // Force pushes
-      if ('beforeCommit' in node && 'afterCommit' in node && node.beforeCommit && node.afterCommit) {
+      if (
+        'beforeCommit' in node &&
+        'afterCommit' in node &&
+        node.beforeCommit &&
+        node.afterCommit
+      ) {
         const afterCommitMap = keyBy(
           node.afterCommit.history.edges,
           (connection: CommitEdge) => connection.node.oid

--- a/src/cycle-time/hasForcePush.ts
+++ b/src/cycle-time/hasForcePush.ts
@@ -2,6 +2,6 @@ import { PullRequest } from '../generated/types';
 
 export const hasForcePush = (pullRequest: PullRequest) => {
   return pullRequest.timelineItems.edges.some(({ node }) => {
-    return 'beforeCommit' in node;
+    return 'beforeCommit' in node || 'afterCommit' in node;
   });
 };

--- a/src/cycle-time/reviewTime.ts
+++ b/src/cycle-time/reviewTime.ts
@@ -35,7 +35,7 @@ function uncertainHistory(pullRequest: PullRequest) {
 
   // If the  initial commit and after the pull request creation date
   // the PR has likely been force pushed locally
-  return +new Date(pullRequest.createdAt) < +new Date(initialCommit)
+  return +new Date(pullRequest.createdAt) < +new Date(initialCommit);
 }
 
 export function findDeploymentTime(
@@ -47,7 +47,8 @@ export function findDeploymentTime(
     return 'label' in edge.node && edge.node.label.name === 'deployed-PROD';
   });
 
-  if(deploymentEvent && "createdAt" in deploymentEvent.node) return deploymentEvent.node.createdAt;
+  if (deploymentEvent && 'createdAt' in deploymentEvent.node)
+    return deploymentEvent.node.createdAt;
   return undefined;
 }
 
@@ -69,9 +70,11 @@ export function commitToPullRequest(
 
   if (!initialCommit) return undefined;
 
-
   if (uncertainHistory(pullRequest)) return undefined;
-  return differenceInBusinessDays(new Date(pullRequest.createdAt), new Date(initialCommit));
+  return differenceInBusinessDays(
+    new Date(pullRequest.createdAt),
+    new Date(initialCommit)
+  );
 }
 
 export function daysToFirstReview(
@@ -81,7 +84,10 @@ export function daysToFirstReview(
 
   if (!initialReviewTime) return undefined;
 
-  return differenceInBusinessDays(new Date(initialReviewTime), new Date(pullRequest.createdAt));
+  return differenceInBusinessDays(
+    new Date(initialReviewTime),
+    new Date(pullRequest.createdAt)
+  );
 }
 
 export function reworkTimeInDays(pullRequest: PullRequest): number | undefined {
@@ -90,7 +96,10 @@ export function reworkTimeInDays(pullRequest: PullRequest): number | undefined {
 
   if (!lastReviewTime) return undefined;
 
-  return differenceInBusinessDays(new Date(lastReviewTime), new Date(initialTime));
+  return differenceInBusinessDays(
+    new Date(lastReviewTime),
+    new Date(initialTime)
+  );
 }
 
 export function waitingToDeploy(pullRequest: PullRequest): number | undefined {
@@ -99,11 +108,13 @@ export function waitingToDeploy(pullRequest: PullRequest): number | undefined {
 
   if (!deploymentTime || !lastReviewTime) return undefined;
 
-  return differenceInBusinessDays(new Date(deploymentTime), new Date(lastReviewTime));
+  return differenceInBusinessDays(
+    new Date(deploymentTime),
+    new Date(lastReviewTime)
+  );
 }
 
 export function cycleTime(pullRequest: PullRequest): number | undefined {
-
   if (pullRequest.state !== 'MERGED' || uncertainHistory(pullRequest)) {
     return undefined;
   }
@@ -118,5 +129,8 @@ export function commitToMerge(pullRequest: PullRequest): number | undefined {
 
   if (!initialCommit || !pullRequest.mergedAt) return undefined;
 
-  return differenceInBusinessDays(new Date(pullRequest.mergedAt), new Date(initialCommit));
+  return differenceInBusinessDays(
+    new Date(pullRequest.mergedAt),
+    new Date(initialCommit)
+  );
 }

--- a/src/cycle-time/reviewTime.ts
+++ b/src/cycle-time/reviewTime.ts
@@ -30,11 +30,14 @@ function findReviewTime(
 }
 
 function uncertainHistory(pullRequest: PullRequest) {
-  const initialCommit = getEarliestCommitAt(pullRequest);
-
-  // If the  initial commit and after the pull request creation date
-  // the PR has likely been force pushed locally
-  return +new Date(pullRequest.createdAt) < +new Date(initialCommit);
+  // We cant be sure about cycle time if we come across a force push event
+  // that is missing a beforeCommit or an afterCommit
+  return pullRequest.timelineItems.edges.some(({ node }) => {
+    return (
+      ('beforeCommit' in node && !node.beforeCommit) ||
+      ('afterCommit' in node && !node.afterCommit)
+    );
+  });
 }
 
 export function findDeploymentTime(

--- a/src/cycle-time/reviewTime.ts
+++ b/src/cycle-time/reviewTime.ts
@@ -2,7 +2,6 @@ import differenceInBusinessDays from 'date-fns/differenceInBusinessDays';
 
 import { PullRequest, PullRequestReviewEdge } from '../generated/types';
 import { getEarliestCommitAt } from './getEarliestCommitAt';
-import { hasForcePush } from './hasForcePush';
 
 type PullRequestPredicateType = (
   edge: PullRequestReviewEdge,

--- a/src/cycle-time/transformPullRequest.ts
+++ b/src/cycle-time/transformPullRequest.ts
@@ -8,6 +8,7 @@ import {
   findDeploymentTime,
   commitToMerge,
 } from './reviewTime';
+import { hasForcePush } from './hasForcePush';
 
 import { PullRequestKeyMetrics } from '../types';
 
@@ -42,5 +43,6 @@ export function transformPullRequest(
     waitingToDeploy: waitingToDeploy(pullRequest),
     cycleTime: cycleTime(pullRequest),
     commitToMerge: commitToMerge(pullRequest),
+    forcePush: hasForcePush(pullRequest),
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type PullRequestKeyMetrics = {
   daysToFirstReview?: number;
   reworkTimeInDays?: number;
   waitingToDeploy?: number;
+  forcePush: boolean;
 };
 
 export type PullRequestKeyMetricsNames = keyof PullRequestKeyMetrics;


### PR DESCRIPTION
- Do not attempt to traverse force push history if `beforeCommit` or `afterCommit` is missing
- If `commitToPullRequest` is negative, do not count cycle time metrics
- Add `forcePush` to PullRequestKeyMetrics and display in table for context