### PR TITLE
Added hover state to charts to sync scatter plot to total merged.

### DIFF
--- a/src/Contributions.tsx
+++ b/src/Contributions.tsx
@@ -23,21 +23,39 @@ type Props = {
 
 function Contributions({ login, name, startDate, endDate }: Props) {
   const [activeTab, setActiveTab] = useState('authored');
+  const [pullStartWeekHighlighted, setPullStartWeekHighlighted] =
+    useState(null);
   const handleChange = (event: any, newTab: string) => setActiveTab(newTab);
   const logins = useMemo(() => [login], [login]);
 
-  const { pullRequests: authoredPullRequests, loading: authoredPullsLoading } = usePullRequests({
-    authors: logins,
-    from: startDate,
-    to: endDate,
-  });
+  const { pullRequests: authoredPullRequests, loading: authoredPullsLoading } =
+    usePullRequests({
+      authors: logins,
+      from: startDate,
+      to: endDate,
+    });
 
-  const { pullRequests: reviewedPullRequests, loading: reviewedPullsLoading } = usePullRequests({
-    reviewedBy: logins,
-    excludeAuthors: logins,
-    from: startDate,
-    to: endDate,
-  });
+  const { pullRequests: reviewedPullRequests, loading: reviewedPullsLoading } =
+    usePullRequests({
+      reviewedBy: logins,
+      excludeAuthors: logins,
+      from: startDate,
+      to: endDate,
+    });
+
+  const setStartWeekHighlighted = (state: any) => {
+    if (state.activeLabel) {
+      if (state.activeLabel !== pullStartWeekHighlighted) {
+        setPullStartWeekHighlighted(state.activeLabel);
+      }
+    } else if (pullStartWeekHighlighted !== null) {
+      setPullStartWeekHighlighted(null);
+    }
+  };
+
+  const removeStartWeekHighlighted = () => {
+    setPullStartWeekHighlighted(null);
+  };
 
   if (authoredPullsLoading || reviewedPullsLoading)
     return (
@@ -57,13 +75,18 @@ function Contributions({ login, name, startDate, endDate }: Props) {
           />
         </Grid>
         <Grid item xs={8}>
-          <MetricTiles pullRequests={authoredPullRequests} reviewedPullRequests={reviewedPullRequests} />
+          <MetricTiles
+            pullRequests={authoredPullRequests}
+            reviewedPullRequests={reviewedPullRequests}
+          />
         </Grid>
         <Grid item xs={4}>
           <PullCreationChart
             pullRequests={authoredPullRequests}
             startDate={startDate}
             endDate={endDate}
+            onMouseMove={setStartWeekHighlighted}
+            onMouseLeave={removeStartWeekHighlighted}
           />
         </Grid>
         <Grid item xs={8}>
@@ -71,6 +94,7 @@ function Contributions({ login, name, startDate, endDate }: Props) {
             pullRequests={authoredPullRequests}
             startDate={startDate}
             endDate={endDate}
+            startWeekStringToHighlight={pullStartWeekHighlighted}
           />
         </Grid>
         <Grid item xs={12}>

--- a/src/CycleTimeScatterPlot.tsx
+++ b/src/CycleTimeScatterPlot.tsx
@@ -1,6 +1,9 @@
 import format from 'date-fns/format';
+import parse from 'date-fns/parse';
+import { addWeeks } from 'date-fns';
 import { Paper } from '@mui/material';
 import {
+  Cell,
   ResponsiveContainer,
   Scatter,
   ScatterChart,
@@ -17,6 +20,7 @@ type Props = {
   pullRequests: PullRequestKeyMetrics[];
   startDate: Date;
   endDate: Date;
+  startWeekStringToHighlight?: string | null;
 };
 
 type CycleTimePullMetaData = {
@@ -27,7 +31,12 @@ type CycleTimePullMetaData = {
   pullUrl: string;
 };
 
-function CycleTimeScatterPlot({ pullRequests, startDate, endDate }: Props) {
+function CycleTimeScatterPlot({
+  pullRequests,
+  startDate,
+  endDate,
+  startWeekStringToHighlight,
+}: Props) {
   const data: CycleTimePullMetaData[] = [];
   const gitHubBaseUri = useGitHubBaseUri();
 
@@ -83,11 +92,30 @@ function CycleTimeScatterPlot({ pullRequests, startDate, endDate }: Props) {
           />
           <Scatter
             data={data}
-            fill="#8884d8"
             onClick={(props) => {
               window.open(props.pullUrl, '_blank');
             }}
-          />
+          >
+            {data.map((entry, index) => {
+              let fillValue = '#8884d8';
+              if (startWeekStringToHighlight) {
+                const startDate = parse(
+                  startWeekStringToHighlight,
+                  'MM-dd-yy',
+                  new Date()
+                );
+
+                if (
+                  new Date(entry.unixTimestamp) > startDate &&
+                  new Date(entry.unixTimestamp) < addWeeks(startDate, 1)
+                ) {
+                  fillValue = '0f0e2c';
+                }
+              }
+
+              return <Cell key={`cell-${index}`} fill={fillValue} />;
+            })}
+          </Scatter>
         </ScatterChart>
       </ResponsiveContainer>
     </Paper>

--- a/src/PullCreationChart.tsx
+++ b/src/PullCreationChart.tsx
@@ -17,6 +17,8 @@ type Props = {
   pullRequests: PullRequestKeyMetrics[];
   startDate: Date;
   endDate: Date;
+  onMouseMove?: any;
+  onMouseLeave?: any;
 };
 
 type PullCreationWeekMetaData = {
@@ -28,7 +30,13 @@ type PullCreationWeekMetaData = {
   pullsMerged: number;
 };
 
-function PullCreationChart({ pullRequests, startDate, endDate }: Props) {
+function PullCreationChart({
+  pullRequests,
+  startDate,
+  endDate,
+  onMouseMove,
+  onMouseLeave,
+}: Props) {
   const data: PullCreationWeekMetaData[] = [];
 
   //TODO - this is typed loosely
@@ -92,7 +100,11 @@ function PullCreationChart({ pullRequests, startDate, endDate }: Props) {
   return (
     <Paper elevation={0} sx={{ height: '100%' }}>
       <ResponsiveContainer height={350}>
-        <LineChart data={data}>
+        <LineChart
+          data={data}
+          onMouseMove={onMouseMove}
+          onMouseLeave={onMouseLeave}
+        >
           <XAxis dataKey="weekString" scale="band" />
           <YAxis />
           <Tooltip />


### PR DESCRIPTION
This PR updates the hover state on mouseover of the line chart. It's generally performant, but it causes a rerender to occur so there's just a bit of jank on the line chart (interestingly, the scatter plot is seamless). I noticed Contributions.tsx is rendering multiple times, so fixing that may help, but curious if the tradeoff on this feels ok. It may also be less noticeable on a production build.

![Screen Shot 2022-05-04 at 7 25 05 PM](https://user-images.githubusercontent.com/7210022/166841630-18e81baa-29e6-404f-bfc5-7f68c11bad07.png)
