### PR TITLE
Updated data grid toolbar visuals

### DIFF
--- a/src/PullRequestTableToolbar.tsx
+++ b/src/PullRequestTableToolbar.tsx
@@ -1,10 +1,30 @@
+import { Box, Button, ButtonGroup } from '@mui/material';
 import {
   GridToolbarContainer,
   GridToolbarColumnsButton,
   GridToolbarExport,
   useGridApiContext,
 } from '@mui/x-data-grid';
-import { Button, ButtonGroup } from '@mui/material';
+import { GridApiCommunity } from '@mui/x-data-grid/models/api/gridApiCommunity';
+
+function compareCurrentSortState(
+  apiRef: React.MutableRefObject<GridApiCommunity>,
+  column: string,
+  direction: string
+) {
+  const currentSortModel = apiRef.current.getSortModel();
+
+  if (
+    currentSortModel &&
+    currentSortModel.length > 0 &&
+    currentSortModel[0].field === column &&
+    currentSortModel[0].sort === direction
+  ) {
+    return true;
+  }
+
+  return false;
+}
 
 function PullRequestTableToolbar() {
   const apiRef = useGridApiContext();
@@ -13,6 +33,7 @@ function PullRequestTableToolbar() {
     <GridToolbarContainer style={{ height: 50 }}>
       <ButtonGroup variant="text">
         <Button
+          disabled={compareCurrentSortState(apiRef, 'created', 'desc')}
           onClick={() => {
             apiRef.current.sortColumn(
               apiRef.current.getColumn('created'),
@@ -23,6 +44,7 @@ function PullRequestTableToolbar() {
           Created At
         </Button>
         <Button
+          disabled={compareCurrentSortState(apiRef, 'reviews', 'desc')}
           onClick={() => {
             apiRef.current.sortColumn(
               apiRef.current.getColumn('reviews'),
@@ -33,6 +55,7 @@ function PullRequestTableToolbar() {
           Most Reviewed
         </Button>
         <Button
+          disabled={compareCurrentSortState(apiRef, 'cycleTime', 'desc')}
           onClick={() => {
             apiRef.current.sortColumn(
               apiRef.current.getColumn('cycleTime'),
@@ -43,6 +66,7 @@ function PullRequestTableToolbar() {
           Longest Cycles
         </Button>
         <Button
+          disabled={compareCurrentSortState(apiRef, 'totalCodeChanges', 'desc')}
           onClick={() => {
             apiRef.current.sortColumn(
               apiRef.current.getColumn('totalCodeChanges'),
@@ -53,7 +77,7 @@ function PullRequestTableToolbar() {
           Most Changes
         </Button>
       </ButtonGroup>
-
+      <Box sx={{ flexGrow: 1 }}></Box>
       <GridToolbarColumnsButton />
       <GridToolbarExport />
     </GridToolbarContainer>


### PR DESCRIPTION
https://github.com/blamattina/githelper/issues/31

* Updated to use disabled state when a preset is in effect, regardless of whether or not it was used to get in that state
* Moved columns/export to far right to make visually cleaner


![Screen Shot 2022-05-07 at 5 44 25 PM](https://user-images.githubusercontent.com/7210022/167272612-f9a37492-56b8-4839-9197-93b2df64828c.png)
.