### PR TITLE
Fix a bug for an API error state

### DIFF
--- a/src/ContributionsRadarChart.tsx
+++ b/src/ContributionsRadarChart.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQuery } from '@apollo/client';
 import { loader } from 'graphql.macro';
 import {
@@ -11,7 +10,9 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import Paper from '@mui/material/Paper';
+import { Paper, Typography } from '@mui/material';
+import DataThresholdingIcon from '@mui/icons-material/DataThresholding';
+import { differenceInDays } from 'date-fns';
 
 const USER_CONTRIBUTIONS_QUERY = loader('./queries/user-contributions.graphql');
 
@@ -35,6 +36,29 @@ function ContributionsRadarChart({ author, startDate, endDate }: Props) {
   );
 
   if (loading) return <div>Loading</div>;
+
+  /* If data does not return due to asking for over a year, show a fail state
+   * Future optimization should be to page through year at a time and
+   * combine, but this prevents a page crash
+   */
+  if (!data.user && differenceInDays(endDate, startDate) > 365) {
+    return (
+      <Paper elevation={0} sx={{ height: '100%', padding: '50px' }}>
+        <Typography
+          align="center"
+          variant="h5"
+          sx={{ paddingLeft: '50px', paddingRight: '50px' }}
+        >
+          Cannot Support More than a Years Data
+        </Typography>
+        <Typography align="center">
+          <DataThresholdingIcon sx={{ height: 150, width: 150 }}>
+            Testing this is longer
+          </DataThresholdingIcon>
+        </Typography>
+      </Paper>
+    );
+  }
 
   const {
     totalCommitContributions,


### PR DESCRIPTION
If the user-contributions query requests more then a years worth of data, it returns an error state, which currently causes a full page crash. This PR fixes the bug by showing an error state for the radar bar instead of crashing the page.

Couple notes here:
* A better fix longer term would probably be to page through the years and combine, but deferring that for now and just fixing crash gracefully. Will capture this in an issue.
* The logic to catch the error state is a bit weird intentionally. The API's behavior is not exactly a year, despite what error message says. I think it has to do with the actual months, so I let it fail and then check if it's an actual year or more.

![Screen Shot 2022-05-08 at 10 33 31 AM](https://user-images.githubusercontent.com/7210022/167301305-fa0d5de4-3818-4c00-9b0f-33e8707ec0c0.png)

Follow-on issue here: https://github.com/blamattina/githelper/issues/55