### PR TITLE
Adds support for Google Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "prettier": "^2.5.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-ga4": "^1.4.1",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.0",
         "react-sparklines": "^1.7.0",
@@ -17778,6 +17779,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-ga4": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
+      "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -34388,6 +34394,11 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-ga4": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-1.4.1.tgz",
+      "integrity": "sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w=="
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prettier": "^2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-ga4": "^1.4.1",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.0",
     "react-sparklines": "^1.7.0",

--- a/src/Application.tsx
+++ b/src/Application.tsx
@@ -11,6 +11,9 @@ import GitHubTokensProvider, {
   GitHubTokensContext,
 } from './auth/GitHubTokensProvider';
 import GitRepoActivityPage from './GitRepoActivityPage';
+import ReactGA from 'react-ga4';
+
+const REACT_TRACKING_ID = 'PLACEHOLDER';
 
 const GitHubServerIndexRedirect: React.FC = () => {
   const { getGitHubTokens } = useContext(GitHubTokensContext);
@@ -20,6 +23,11 @@ const GitHubServerIndexRedirect: React.FC = () => {
 };
 
 const Application: React.FC = ({ children }) => {
+  ReactGA.initialize(REACT_TRACKING_ID, {
+    //disables GA locally - TODO should be passed as environment variable, this is kind of a hack.
+    testMode: window.location.href.includes('localhost'),
+  });
+
   return (
     <Box sx={{ backgroundColor: 'rgb(240, 240, 240)', minHeight: '100vh' }}>
       <CssBaseline />

--- a/src/Application.tsx
+++ b/src/Application.tsx
@@ -13,7 +13,7 @@ import GitHubTokensProvider, {
 import GitRepoActivityPage from './GitRepoActivityPage';
 import ReactGA from 'react-ga4';
 
-const REACT_TRACKING_ID = 'PLACEHOLDER';
+const REACT_TRACKING_ID = 'G-HQG37QXW8S';
 
 const GitHubServerIndexRedirect: React.FC = () => {
   const { getGitHubTokens } = useContext(GitHubTokensContext);

--- a/src/GitOrgActivityPage.tsx
+++ b/src/GitOrgActivityPage.tsx
@@ -1,11 +1,12 @@
-import React, { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import GitOrgChooser from './GitOrgChooser';
 import GitTeamChooser from './GitTeamChooser';
 import TeamContributionsMembersHoC from './TeamContributionsMembersHoC';
 import TimeSpanSelect from './time-span/TimeSpanSelect';
 import { useTimePeriod } from './time-span/useTimeSpan';
+import ReactGA from 'react-ga4';
 
 export type OrganizationOption = {
   name: string;
@@ -20,6 +21,14 @@ export type TeamOption = {
 function GitOrgActivityPage() {
   const params = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    ReactGA.send({
+      hitType: 'pageview',
+      page: '/org',
+    });
+  }, [location.pathname]);
 
   const { startDate, endDate, timePeriod, setTimePeriod } = useTimePeriod();
 

--- a/src/GitRepoActivityPage.tsx
+++ b/src/GitRepoActivityPage.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import GitRepoChooser from './GitRepoChooser';
 import RepoContributions from './RepoContributions';
 import TimeSpanSelect from './time-span/TimeSpanSelect';
 import { useTimePeriod } from './time-span/useTimeSpan';
+import ReactGA from 'react-ga4';
 
 export type RepoOption = {
   label: string;
@@ -15,6 +16,14 @@ export type RepoOption = {
 function GitRepoActivityPage() {
   const params = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    ReactGA.send({
+      hitType: 'pageview',
+      page: '/repo',
+    });
+  }, [location.pathname]);
 
   const { startDate, endDate, timePeriod, setTimePeriod } = useTimePeriod();
 

--- a/src/GitUserActivityPage.tsx
+++ b/src/GitUserActivityPage.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import GitUserChooser from './GitUserChooser';
 import Contributions from './Contributions';
 import TimeSpanSelect from './time-span/TimeSpanSelect';
 import { useTimePeriod } from './time-span/useTimeSpan';
+import ReactGA from 'react-ga4';
 
 export type AuthorOption = {
   label: string;
@@ -15,6 +16,14 @@ export type AuthorOption = {
 function GitUserActivityPage() {
   const params = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    ReactGA.send({
+      hitType: 'pageview',
+      page: '/users',
+    });
+  }, [location.pathname]);
 
   const { startDate, endDate, timePeriod, setTimePeriod } = useTimePeriod();
 

--- a/src/auth/GitHubTokenForm.tsx
+++ b/src/auth/GitHubTokenForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useContext } from 'react';
+import React, { useState, useCallback, useContext, useEffect } from 'react';
 import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -6,14 +6,18 @@ import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
 import { useNavigate } from 'react-router-dom';
 import { GitHubTokensContext } from './GitHubTokensProvider';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useLocation } from 'react-router-dom';
+import ReactGA from 'react-ga4';
 
 const GitApiHostForm: React.FC = () => {
   const { addGitHubToken } = useContext(GitHubTokensContext);
   const [searchParams] = useSearchParams();
-  const [hostname, setHostname] = useState(searchParams.get('gitHubHostname') || 'api.github.com');
+  const [hostname, setHostname] = useState(
+    searchParams.get('gitHubHostname') || 'api.github.com'
+  );
   const [token, setToken] = useState('');
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleSave = useCallback(() => {
     addGitHubToken({
@@ -22,6 +26,13 @@ const GitApiHostForm: React.FC = () => {
     });
     navigate(`/${hostname}`);
   }, [hostname, token, navigate, addGitHubToken]);
+
+  useEffect(() => {
+    ReactGA.send({
+      hitType: 'pageview',
+      page: '/new',
+    });
+  }, [location.pathname]);
 
   return (
     <Grid


### PR DESCRIPTION
This pull request pulls in the `react-ga4` library and configures

After this, the following page views will be tracked:
- /new
- /users
- /org
- /repo

The logic currently works in a way that if a new path occurs a new page view will track (for example, changing user you are looking at on `/users`), but it will not track a new page view if query parameters change (for example, a new date range is selected).

This should not track anything locally, although right now this uses a bit of a hack to prevent this from happening and we should figure out how to pass in an env variable appropriately.

Finally, before merging this PR, a GA4 account must be created and the property ID needs to be put in to return `PLACEHOLDER`.