### PR TITLE
Fix Firefox and Safari

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/PullCreationChart.tsx
+++ b/src/PullCreationChart.tsx
@@ -151,10 +151,10 @@ function PullCreationChart({
           margin={{ top: 20, left: 0, right: 20, bottom: 20 }}
         >
           <XAxis
-            dataKey="weekString"
+            dataKey="week"
             scale="band"
-            tickFormatter={(unixTimestamp) =>
-              format(new Date(unixTimestamp), 'MMM dd')
+            tickFormatter={(date) =>
+              format(date, 'MMM dd')
             }
           />
           <YAxis width={50} />


### PR DESCRIPTION
`weekString` is formatted MM-DD-YY. It throws an invalid date exception in Safari and Firefox. This PR switches to using a JS Date object already on the aggregate (`week`).