### PR TITLE
Add Ability to Manage Keys

### DIFF
--- a/src/Application.tsx
+++ b/src/Application.tsx
@@ -3,6 +3,7 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import CssBaseline from '@mui/material/CssBaseline';
 import Box from '@mui/material/Box';
 import GitHubTokenForm from './auth/GitHubTokenForm';
+import GitHubUpdateTokens from './auth/GitHubUpdateTokens';
 import GitOrgActivityPage from './GitOrgActivityPage';
 import GitUserActivityPage from './GitUserActivityPage';
 import GitHubApolloProvider from './auth/GitHubApolloProvider';
@@ -53,6 +54,7 @@ const Application: React.FC = ({ children }) => {
                 element={<GitRepoActivityPage />}
               />
             </Route>
+            <Route path="manage" element={<GitHubUpdateTokens />} />
             <Route index element={<GitHubServerIndexRedirect />} />
           </Route>
         </Routes>

--- a/src/auth/GitHubServerNav.tsx
+++ b/src/auth/GitHubServerNav.tsx
@@ -188,6 +188,13 @@ const GitHubServerNav: React.FC = () => {
                       </NavLink>
                     </Typography>
                   </MenuItem>
+                  <MenuItem key={'manage'} onClick={handleCloseUserMenu}>
+                    <Typography textAlign="center">
+                      <NavLink to="manage" style={linkStyle}>
+                        Manage GitHub keys
+                      </NavLink>
+                    </Typography>
+                  </MenuItem>
 
                   {gitHubTokens && gitHubTokens.length > 0 && <Divider />}
 

--- a/src/auth/GitHubTokensProvider.tsx
+++ b/src/auth/GitHubTokensProvider.tsx
@@ -1,17 +1,26 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { readGitHubTokens, writeGitHubToken, GitHubToken } from './tokenStore';
+import {
+  deleteGitHubToken,
+  readGitHubTokens,
+  writeGitHubToken,
+  GitHubToken,
+} from './tokenStore';
 
 type GitHubTokensContextType = {
   getGitHubTokens(): GitHubToken[];
   getGitHubToken(hostname: string): GitHubToken | undefined;
   addGitHubToken(gitHubToken: GitHubToken): void;
-}
+  deleteGitHubToken(gitHubToken: GitHubToken): void;
+};
 
-export const GitHubTokensContext = React.createContext<GitHubTokensContextType>({
-  getGitHubTokens: () => [],
-  getGitHubToken: () => undefined,
-  addGitHubToken: () => {},
-});
+export const GitHubTokensContext = React.createContext<GitHubTokensContextType>(
+  {
+    getGitHubTokens: () => [],
+    getGitHubToken: () => undefined,
+    addGitHubToken: () => {},
+    deleteGitHubToken: () => {},
+  }
+);
 
 const GitHubTokensProvider: React.FC = ({ children }) => {
   const [gitHubTokens, setGitHubTokens] = useState(readGitHubTokens());
@@ -22,16 +31,20 @@ const GitHubTokensProvider: React.FC = ({ children }) => {
     [gitHubTokens]
   );
 
-  const addGitHubToken = useCallback((gitHubToken: GitHubToken) => {
-    writeGitHubToken(gitHubToken);
-    setGitHubTokens(readGitHubTokens());
-  }, [setGitHubTokens]);
+  const addGitHubToken = useCallback(
+    (gitHubToken: GitHubToken) => {
+      writeGitHubToken(gitHubToken);
+      setGitHubTokens(readGitHubTokens());
+    },
+    [setGitHubTokens]
+  );
 
   const tokenStore = useMemo(() => {
     return {
       getGitHubTokens: () => gitHubTokens,
       addGitHubToken,
       getGitHubToken,
+      deleteGitHubToken,
     };
   }, [gitHubTokens, getGitHubToken, addGitHubToken]);
 

--- a/src/auth/GitHubUpdateTokens.tsx
+++ b/src/auth/GitHubUpdateTokens.tsx
@@ -1,0 +1,182 @@
+import React, { useContext, useEffect, useState } from 'react';
+import DeleteIcon from '@mui/icons-material/Delete';
+import Grid from '@mui/material/Grid';
+import TextField from '@mui/material/TextField';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Paper from '@mui/material/Paper';
+import { GitHubTokensContext } from './GitHubTokensProvider';
+import { useLocation } from 'react-router-dom';
+import ReactGA from 'react-ga4';
+import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+
+const GitHubUpdateTokens: React.FC = () => {
+  const { addGitHubToken, deleteGitHubToken, getGitHubTokens } =
+    useContext(GitHubTokensContext);
+
+  const [updateKeys, setUpdateKeys] = useState<{ [key: string]: string }>({});
+  const [updateOpen, setUpdateOpen] = useState(false);
+  const [updateHostname, setUpdateHostname] = useState('');
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteHostname, setDeleteHostname] = useState('');
+  const [gitHubTokens, setGitHubTokens] = useState(getGitHubTokens());
+
+  const location = useLocation();
+
+  useEffect(() => {
+    ReactGA.send({
+      hitType: 'pageview',
+      page: '/manage',
+    });
+  }, [location.pathname]);
+
+  const handleClickUpdateOpen = (hostname: string) => {
+    setUpdateHostname(hostname);
+    setUpdateOpen(true);
+  };
+
+  const handleClickUpdateConfirm = () => {
+    const newToken = {
+      hostname: updateHostname,
+      token: updateKeys[updateHostname],
+    };
+
+    deleteGitHubToken(newToken);
+    addGitHubToken(newToken);
+    updateKeys[updateHostname] = '';
+    setUpdateKeys(updateKeys);
+
+    handleClickUpdateClose();
+  };
+
+  const handleClickUpdateClose = () => {
+    setUpdateHostname('');
+    setUpdateOpen(false);
+  };
+
+  const handleClickDeleteOpen = (hostname: string) => {
+    setDeleteHostname(hostname);
+    setDeleteOpen(true);
+  };
+
+  const handleClickDeleteConfirm = () => {
+    deleteGitHubToken({
+      hostname: deleteHostname,
+      token: '',
+    });
+
+    setGitHubTokens(
+      gitHubTokens.filter(
+        (gitHubToken) => gitHubToken.hostname !== deleteHostname
+      )
+    );
+
+    handleClickDeleteClose();
+  };
+
+  const handleClickDeleteClose = () => {
+    setDeleteHostname('');
+    setDeleteOpen(false);
+  };
+
+  return (
+    <Grid container justifyContent="center">
+      <Grid item xs={8}>
+        <Paper elevation={0} sx={{ padding: 4 }}>
+          <Typography variant="h4" sx={{ marginBottom: 6 }}>
+            Manage GitHub Keys
+          </Typography>
+
+          {gitHubTokens.map(({ hostname }: { hostname: string }) => (
+            <Paper sx={{ padding: '8px', margin: '8px' }} key={hostname}>
+              <Grid container>
+                <Grid item xs={4}>
+                  <Typography variant="subtitle1" sx={{ margin: '8px' }}>
+                    {hostname}
+                  </Typography>
+                </Grid>
+
+                <Grid item xs={8}>
+                  <Box display="flex" justifyContent="flex-end">
+                    <TextField
+                      onChange={(
+                        event: React.ChangeEvent<HTMLInputElement>
+                      ) => {
+                        let updateKeysObj = { ...updateKeys };
+                        updateKeysObj[hostname] = event.target.value;
+                        setUpdateKeys(updateKeysObj);
+                      }}
+                      size="small"
+                      sx={{ margin: '8px' }}
+                      value={updateKeys[hostname] || ''}
+                      InputProps={{
+                        endAdornment: (
+                          <Button
+                            onClick={() => handleClickUpdateOpen(hostname)}
+                          >
+                            Update
+                          </Button>
+                        ),
+                      }}
+                    ></TextField>
+                    <Button
+                      variant="contained"
+                      color="error"
+                      sx={{ margin: '8px' }}
+                      startIcon={<DeleteIcon />}
+                      onClick={() => handleClickDeleteOpen(hostname)}
+                    >
+                      Delete Key
+                    </Button>
+                  </Box>
+                </Grid>
+              </Grid>
+            </Paper>
+          ))}
+        </Paper>
+      </Grid>
+      <Dialog open={updateOpen}>
+        <DialogTitle>
+          {`Are you sure you want to update the key for ${updateHostname}?`}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Updating this key cannot be undone. Your current key will be cleared
+            and unretrievable.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClickUpdateClose}>Disagree</Button>
+          <Button onClick={handleClickUpdateConfirm} autoFocus>
+            Agree
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog open={deleteOpen}>
+        <DialogTitle>
+          {`Are you sure you want to delete the key for ${deleteHostname}?`}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Deleting this key cannot be undone. You will be able to add a new
+            key later, but any data associated with this git server will be
+            lost.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClickDeleteClose}>Disagree</Button>
+          <Button onClick={handleClickDeleteConfirm} autoFocus>
+            Agree
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Grid>
+  );
+};
+
+export default GitHubUpdateTokens;

--- a/src/auth/tokenStore.ts
+++ b/src/auth/tokenStore.ts
@@ -22,3 +22,9 @@ export function writeGitHubToken(gitHubToken: GitHubToken) {
   tokens.push(gitHubToken);
   localStorage.setItem(KEY, JSON.stringify(tokens));
 }
+
+export function deleteGitHubToken(gitHubToken: GitHubToken) {
+  let tokens = readGitHubTokens();
+  tokens = tokens.filter((token) => token.hostname !== gitHubToken.hostname);
+  localStorage.setItem(KEY, JSON.stringify(tokens));
+}


### PR DESCRIPTION
This PR gives users the ability to update or delete their keys through a new UI on the route `/manage` (threw this together after my API key expired the other day).

Couple things this PR doesn't handle that may make good followups:

- Merge the new key page with this so only one route to manage all.
- Intelligently link the error state for expired (401 errors) to this page.

![Screen Shot 2022-10-31 at 2 27 26 PM](https://user-images.githubusercontent.com/7210022/199082486-0bef24b4-696b-470d-aaff-4c80d2680900.png)


https://github.com/blamattina/githelper/issues/77