### PR TITLE
Prevent fetching of PRs for empty teams

### DIFF
--- a/src/GitTeamChooser.tsx
+++ b/src/GitTeamChooser.tsx
@@ -70,10 +70,13 @@ const GitTeamChooser = ({
   let options: any = [];
   let defaultValue = null;
   if (data?.organization?.teams?.edges) {
-    options = data.organization.teams.edges.map((team: any) => ({
-      name: team.node.name,
-      label: team.node.name,
-    }));
+    options = data.organization.teams.edges
+      // Filter out empty teams
+      .filter((team: any) => team.node.members.nodes.length)
+      .map((team: any) => ({
+        name: team.node.name,
+        label: team.node.name,
+      }));
   }
 
   if (

--- a/src/TeamContributionsMembersHoC.tsx
+++ b/src/TeamContributionsMembersHoC.tsx
@@ -4,6 +4,8 @@ import { LinearProgress } from '@mui/material';
 import type { OrganizationOption, TeamOption } from './GitOrgActivityPage';
 import { loader } from 'graphql.macro';
 import TeamContributions from './TeamContributions';
+import { ErrorMessage } from './components/ErrorMessage';
+import { WarningAmber } from '@mui/icons-material';
 
 const TEAM_SEARCH = loader('./queries/team-search.graphql');
 
@@ -48,6 +50,16 @@ function TeamContributionsMembersHoC({
       <Box sx={{ paddingTop: 20 }}>
         <LinearProgress color="success" />
       </Box>
+    );
+  }
+
+  if (!members.length) {
+    return (
+      <ErrorMessage
+        title="The selected team has no members"
+        Icon={WarningAmber}
+        color="info"
+      />
     );
   }
 

--- a/src/auth/GitHubApolloProvider.tsx
+++ b/src/auth/GitHubApolloProvider.tsx
@@ -9,8 +9,7 @@ import {
 import { onError } from '@apollo/client/link/error';
 import { GitHubTokensContext } from './GitHubTokensProvider';
 import { useParams, Navigate, createSearchParams } from 'react-router-dom';
-import ErrorTwoToneIcon from '@mui/icons-material/ErrorTwoTone';
-import { Box, Grid, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import { ErrorMessage } from '../components/ErrorMessage';
 
 function makeUri(hostname: string): string {

--- a/src/auth/GitHubApolloProvider.tsx
+++ b/src/auth/GitHubApolloProvider.tsx
@@ -11,6 +11,7 @@ import { GitHubTokensContext } from './GitHubTokensProvider';
 import { useParams, Navigate, createSearchParams } from 'react-router-dom';
 import ErrorTwoToneIcon from '@mui/icons-material/ErrorTwoTone';
 import { Box, Grid, Typography } from '@mui/material';
+import { ErrorMessage } from '../components/ErrorMessage';
 
 function makeUri(hostname: string): string {
   if (hostname === 'api.github.com') return 'https://api.github.com/graphql';
@@ -60,24 +61,14 @@ const GitHubApolloProvider: React.FC = ({ children }) => {
   if (linkErrorMessage) {
     return (
       <Box sx={{ flexGrow: 1 }}>
-        <Grid container>
-          <Grid xs={4}></Grid>
-          <Grid xs={4} item style={{ textAlign: 'center' }}>
-            <ErrorTwoToneIcon sx={{ fontSize: 250 }} color="error" />
-          </Grid>
-          <Grid xs={4}></Grid>
-          <Grid xs={3}></Grid>
-          <Grid xs={6} style={{ textAlign: 'center' }} item>
-            <Typography variant="h5">
-              {linkErrorMessage}
-              <br />
-              <br />
-              {gitHubHostname !== 'api.github.com' &&
-                'If your company requires VPN access to GitHub Enterprise, check to see if you are on the network.'}
-            </Typography>
-          </Grid>
-          <Grid xs={3}></Grid>
-        </Grid>
+        <ErrorMessage
+          title={linkErrorMessage}
+          description={
+            gitHubHostname !== 'api.github.com'
+              ? 'If your company requires VPN access to GitHub Enterprise, check to see if you are on the network.'
+              : undefined
+          }
+        />
       </Box>
     );
   }

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,0 +1,33 @@
+import { Grid, SvgIconTypeMap, Typography } from '@mui/material';
+import DangerousIcon from '@mui/icons-material/Dangerous';
+import { OverridableComponent } from '@mui/material/OverridableComponent';
+
+type Props = {
+  title: String;
+  description?: String;
+  Icon?: OverridableComponent<SvgIconTypeMap>;
+  color?: 'error' | 'warning' | 'success' | 'info';
+};
+
+export function ErrorMessage({
+  title,
+  description,
+  Icon = DangerousIcon,
+  color = 'error',
+}: Props) {
+  return (
+    <Grid container>
+      <Grid xs={4}></Grid>
+      <Grid xs={4} item style={{ textAlign: 'center' }}>
+        <Icon sx={{ fontSize: 250 }} color={color} />
+      </Grid>
+      <Grid xs={4}></Grid>
+      <Grid xs={3}></Grid>
+      <Grid xs={6} style={{ textAlign: 'center' }} item>
+        <Typography variant="h5">{title}</Typography>
+        <br />
+        <Typography variant="h6">{description}</Typography>
+      </Grid>
+    </Grid>
+  );
+}

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -16,13 +16,10 @@ export function ErrorMessage({
   color = 'error',
 }: Props) {
   return (
-    <Grid container>
-      <Grid xs={4}></Grid>
-      <Grid xs={4} item style={{ textAlign: 'center' }}>
+    <Grid container direction="column">
+      <Grid xs={6} item style={{ textAlign: 'center' }}>
         <Icon sx={{ fontSize: 250 }} color={color} />
       </Grid>
-      <Grid xs={4}></Grid>
-      <Grid xs={3}></Grid>
       <Grid xs={6} style={{ textAlign: 'center' }} item>
         <Typography variant="h5">{title}</Typography>
         <br />


### PR DESCRIPTION
When fetching pull requests for a team with no members, the resulting github search query is `is:PR created:startdate..enddate` which will fetch all pull requests for the given date range regardless of team or author.


This PR adds two safeguards:

1. Check for team membership and displays an error state when an empty team is selected. This is necessary incase an empty team is selected via URL path parameter
2. Filter empty teams from options in `GitTeamChooser`