### PR TITLE
Added recognition for additional extension of a Yaml file (.yml)

### DIFF
--- a/src/extensionMap.ts
+++ b/src/extensionMap.ts
@@ -21,6 +21,7 @@ export const extensionMap: { [key: string]: LanguageType } = {
   '(.*)\\.ts': LanguageType.Typescript,
   '(.*)\\.tsx': LanguageType.Typescript,
   '(.*)\\.xml': LanguageType.XML,
+  '(.*)\\.yml': LanguageType.Yaml,
   '(.*)\\.yaml': LanguageType.Yaml,
   '(.*)yarn\\.lock': LanguageType.Yarn,
 };


### PR DESCRIPTION
A Yaml file can be `.yml` or `.yaml`, and prior to this commit the language only detected `.yaml`.