### PR TITLE
Fix GraphQL Queries being Cached Locally during Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@
 npm install
 npm start
 ```
+
+## Generate New GraphQL Queries
+
+If you change any oft he GraphQL queries in `src/queries`, you will need to regenerate the types. You can do this by running:
+
+```
+npm run generate
+```
+
+You will need to restart your development server after to clear the cached queries.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "web-vitals": "^2.1.2"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "rm -rf ./node_modules/.cache && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "generate": "graphql-codegen --config codegen.yml",


### PR DESCRIPTION
This PR fixes the current issue:
1. Make a change to any GraphQL query in `src/queries`
2. Run `npm run generate`
3. Start the server with `npm start`

If you look at the query results, you won't see the new GraphQL query running. I did some research and found these documenting the issue:
- [Stack Overflow](https://stackoverflow.com/questions/55783964/clean-create-react-apps-cache-when-importing-graphql-files?rq=1)
- [Babel docs](https://github.com/detrohutt/babel-plugin-import-graphql#install)

During testing, I did see inconsistent results using this however:
```
    "start": "rm -rf ./node_modules/.cache/babel-loader && node index.js"
```

For some reason I can't quite figure out, sometimes the babel-loader directory is missing, even though the queries are clearly being cached. This PR deletes the entire `.cache` which consistently works and should be [safe](https://stackoverflow.com/questions/60773154/is-safe-to-delete-cache-folder-in-node-modules). The one drawback is it is slightly slower on startup.